### PR TITLE
Persistent random server id generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ And use it in your pom file.
     <dependency>
       <groupId>com.imaginarycode.minecraft</groupId>
       <artifactId>RedisBungee</artifactId>
-      <version>0.6.2</version>
+      <version>0.6.3</version>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.imaginarycode.minecraft</groupId>
     <artifactId>RedisBungee</artifactId>
-    <version>0.6</version>
+    <version>0.6.1</version>
 
     <distributionManagement>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,6 @@
     <artifactId>RedisBungee</artifactId>
     <version>0.6.3</version>
 
-    <distributionManagement>
-        <repository>
-            <id>Limework-Maven-Public</id>
-            <url>http://mc.limework.net:8081/repository/public-maven/</url>
-        </repository>
-    </distributionManagement>
-
 
     <repositories>
         <repository>

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
@@ -105,7 +105,7 @@ public final class RedisBungee extends Plugin {
                         servers.add(entry.getKey());
                     else if (nag && nagTime <= 0) {
                         getLogger().warning(entry.getKey() + " is " + (time - stamp) + " seconds behind! (Time not synchronized or server down?) and was removed from heartbeat.");
-                        jedis.hdel("heartbeats",  entry.getKey());
+                        jedis.hdel("heartbeats", entry.getKey());
                     }
                 } catch (NumberFormatException ignored) {
                 }
@@ -415,13 +415,8 @@ public final class RedisBungee extends Plugin {
         final int redisPort = configuration.getInt("redis-port", 6379);
         final boolean useSSL = configuration.getBoolean("useSSL");
         String redisPassword = configuration.getString("redis-password");
-        String serverId;
+        String serverId = configuration.getString("server-id");
         final String randomUUID = UUID.randomUUID().toString();
-        if (configuration.getBoolean("use-random-id-string", false)) {
-            serverId = configuration.getString("server-id") + "-" + randomUUID;
-        } else {
-            serverId = configuration.getString("server-id");
-        }
 
         if (redisPassword != null && (redisPassword.isEmpty() || redisPassword.equals("none"))) {
             redisPassword = null;
@@ -429,12 +424,20 @@ public final class RedisBungee extends Plugin {
 
         // Configuration sanity checks.
         if (serverId == null || serverId.isEmpty()) {
+            /*
+            *  this check causes the config comments to disappear somehow
+            *  I think due snake yaml limitations so as todo: write our own yaml parser?
+            */
             String genId = UUID.randomUUID().toString();
             getLogger().info("Generated server id " + genId + " and saving it to config.");
-            configuration.set("server-id",genId);
+            configuration.set("server-id", genId);
             ConfigurationProvider.getProvider(YamlConfiguration.class).save(configuration, new File(getDataFolder(), "config.yml"));
         } else {
             getLogger().info("Loaded server id " + serverId + '.');
+        }
+
+        if (configuration.getBoolean("use-random-id-string", false)) {
+            serverId = configuration.getString("server-id") + "-" + randomUUID;
         }
 
         if (redisServer != null && !redisServer.isEmpty()) {

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
@@ -415,6 +415,9 @@ public final class RedisBungee extends Plugin {
         final boolean useSSL = configuration.getBoolean("useSSL");
         String redisPassword = configuration.getString("redis-password");
         String serverId = configuration.getString("server-id");
+        if (serverId == null || serverId.isEmpty()) {
+            serverId = UUID.randomUUID().toString();
+        }
 
         if (redisPassword != null && (redisPassword.isEmpty() || redisPassword.equals("none"))) {
             redisPassword = null;

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
@@ -415,9 +415,6 @@ public final class RedisBungee extends Plugin {
         final boolean useSSL = configuration.getBoolean("useSSL");
         String redisPassword = configuration.getString("redis-password");
         String serverId = configuration.getString("server-id");
-        if (serverId == null || serverId.isEmpty()) {
-            serverId = UUID.randomUUID().toString();
-        }
 
         if (redisPassword != null && (redisPassword.isEmpty() || redisPassword.equals("none"))) {
             redisPassword = null;
@@ -425,7 +422,8 @@ public final class RedisBungee extends Plugin {
 
         // Configuration sanity checks.
         if (serverId == null || serverId.isEmpty()) {
-            throw new RuntimeException("server-id is not specified in the configuration or is empty");
+            configuration.set("server-id", UUID.randomUUID().toString());
+            ConfigurationProvider.getProvider(YamlConfiguration.class).save(configuration, new File(getDataFolder(), "config.yml"));
         }
 
         if (redisServer != null && !redisServer.isEmpty()) {

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
@@ -422,8 +422,12 @@ public final class RedisBungee extends Plugin {
 
         // Configuration sanity checks.
         if (serverId == null || serverId.isEmpty()) {
-            configuration.set("server-id", UUID.randomUUID().toString());
+            String genId = UUID.randomUUID().toString();
+            getLogger().info("Generated server id " + genId + " and saving it to config.");
+            configuration.set("server-id",genId);
             ConfigurationProvider.getProvider(YamlConfiguration.class).save(configuration, new File(getDataFolder(), "config.yml"));
+        } else {
+            getLogger().info("Loaded server id " + serverId + '.');
         }
 
         if (redisServer != null && !redisServer.isEmpty()) {

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeConfiguration.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeConfiguration.java
@@ -22,11 +22,7 @@ public class RedisBungeeConfiguration {
 
     public RedisBungeeConfiguration(JedisPool pool, Configuration configuration) {
         this.pool = pool;
-        String serverId = configuration.getString("server-id");
-        if (serverId == null || serverId.isEmpty()) {
-            serverId = UUID.randomUUID().toString();
-        }
-        this.serverId = serverId;
+        this.serverId = configuration.getString("server-id");
 
         this.registerBungeeCommands = configuration.getBoolean("register-bungee-commands", true);
 

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeConfiguration.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeConfiguration.java
@@ -8,6 +8,7 @@ import redis.clients.jedis.JedisPool;
 
 import java.net.InetAddress;
 import java.util.List;
+import java.util.UUID;
 
 public class RedisBungeeConfiguration {
     @Getter
@@ -21,7 +22,12 @@ public class RedisBungeeConfiguration {
 
     public RedisBungeeConfiguration(JedisPool pool, Configuration configuration) {
         this.pool = pool;
-        this.serverId = configuration.getString("server-id");
+        String serverId = configuration.getString("server-id");
+        if (serverId == null || serverId.isEmpty()) {
+            serverId = UUID.randomUUID().toString();
+        }
+        this.serverId = serverId;
+
         this.registerBungeeCommands = configuration.getBoolean("register-bungee-commands", true);
 
         List<String> stringified = configuration.getStringList("exempt-ip-addresses");

--- a/src/main/resources/example_config.yml
+++ b/src/main/resources/example_config.yml
@@ -17,7 +17,7 @@ max-redis-connections: 8
 useSSL: false
 
 
-# An identifier for this BungeeCord instance.
+# An identifier for this BungeeCord instance. Will randomly generate if leaving it blank.
 server-id: "test1"
 # Should use random string? if enabled proxy id will be like this "test1-66cd2aeb-91f3-43a7-a106-e0307b098652"
 # this great for servers who run replicas in Kubernetes or any auto deploying replica service

--- a/src/main/resources/example_config.yml
+++ b/src/main/resources/example_config.yml
@@ -17,7 +17,7 @@ max-redis-connections: 8
 useSSL: false
 
 # An identifier for this BungeeCord instance.
-server-id: test1
+server-id: ""
 
 # Whether or not RedisBungee should install its version of regular BungeeCord commands.
 # Often, the RedisBungee commands are desired, but in some cases someone may wish to

--- a/src/main/resources/example_config.yml
+++ b/src/main/resources/example_config.yml
@@ -16,11 +16,12 @@ max-redis-connections: 8
 # you must disable this if redis version is under 6 you must disable this or connection wont work!!!
 useSSL: false
 
-
 # An identifier for this BungeeCord instance. Will randomly generate if leaving it blank.
 server-id: "test1"
-# Should use random string? if enabled proxy id will be like this "test1-66cd2aeb-91f3-43a7-a106-e0307b098652"
+# Should use random string? if this  is enabled the proxy id will be like this if server-id is test1: "test1-66cd2aeb-91f3-43a7-a106-e0307b098652"
+# or if id is limework-bungee it will be "limework-bungee-66cd2aeb-91f3-43a7-a106-e0307b098652"
 # this great for servers who run replicas in Kubernetes or any auto deploying replica service
+# and used for if proxy died in a kubernetes network and deleted then new proxy setup itself.
 use-random-id-string: false
 
 # Whether or not RedisBungee should install its version of regular BungeeCord commands.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: ${project.name}
 main: com.imaginarycode.minecraft.redisbungee.RedisBungee
 version: ${project.version}
-author: Chunker and Govindas limework
+author: Chunkr and Govindas limework
 authors:
   - chunkr
   - Govindas Limework


### PR DESCRIPTION
## Summary
Implemented a random UUID generation for empty server ids a few weeks ago, and I saw the limework fork has implemented a UUID generation too but it is not exactly what I wanted, so I want to share this PR with the maintainers.

## Goal
This PR generates a random UUID when the initial config is empty, and then it saves the generated id to the config file.

## Details
In the limework's implementation, if you always generate and append a random UUID on the flight, the heartbeat will not work.

Unlike limework's implementation, my UUID generation is persistent, and I use it for cloud deployments. Many instances copy from the same source for config files, generates random proxy ids, and save them. Persistency is required to recover from a crash as there are data in Redis linked to the server id.