### PR TITLE
Allow unsuccessful replacement of BungeeCord thread pool

### DIFF
--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
@@ -224,13 +224,15 @@ public final class RedisBungee extends Plugin {
     public void onEnable() {
         ThreadFactory factory = ((ThreadPoolExecutor) getExecutorService()).getThreadFactory();
         getExecutorService().shutdownNow();
-        ScheduledExecutorService service;
+        ScheduledExecutorService service = Executors.newScheduledThreadPool(24, factory);
         try {
             Field field = Plugin.class.getDeclaredField("service");
             field.setAccessible(true);
-            field.set(this, service = Executors.newScheduledThreadPool(24, factory));
+            ExecutorService builtinService = (ExecutorService) field.get(this);
+            field.set(this, service);
+            builtinService.shutdownNow();
         } catch (Exception e) {
-            throw new RuntimeException("Can't replace BungeeCord thread pool with our own", e);
+            getLogger().log(Level.WARNING, "Can't replace BungeeCord thread pool with our own", e);
         }
         try {
             loadConfig();

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
@@ -223,7 +223,6 @@ public final class RedisBungee extends Plugin {
     @Override
     public void onEnable() {
         ThreadFactory factory = ((ThreadPoolExecutor) getExecutorService()).getThreadFactory();
-        getExecutorService().shutdownNow();
         ScheduledExecutorService service = Executors.newScheduledThreadPool(24, factory);
         try {
             Field field = Plugin.class.getDeclaredField("service");


### PR DESCRIPTION
Port https://github.com/minecrafter/RedisBungee/pull/76

Some BungeeCord forks have different implementation of thread pool and RedisBungee won't load in such case