### PR TITLE
Allow to customize ping events priority via handle-motd-order

### DIFF
--- a/api/src/main/java/com/imaginarycode/minecraft/redisbungee/api/config/HandleMotdOrder.java
+++ b/api/src/main/java/com/imaginarycode/minecraft/redisbungee/api/config/HandleMotdOrder.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2013-present RedisBungee contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ *
+ *  http://www.eclipse.org/legal/epl-v10.html
+ */
+
 package com.imaginarycode.minecraft.redisbungee.api.config;
 
 public enum HandleMotdOrder {

--- a/api/src/main/java/com/imaginarycode/minecraft/redisbungee/api/config/HandleMotdOrder.java
+++ b/api/src/main/java/com/imaginarycode/minecraft/redisbungee/api/config/HandleMotdOrder.java
@@ -1,0 +1,7 @@
+package com.imaginarycode.minecraft.redisbungee.api.config;
+
+public enum HandleMotdOrder {
+    FIRST,
+    NORMAL,
+    LAST
+}

--- a/api/src/main/java/com/imaginarycode/minecraft/redisbungee/api/config/RedisBungeeConfiguration.java
+++ b/api/src/main/java/com/imaginarycode/minecraft/redisbungee/api/config/RedisBungeeConfiguration.java
@@ -25,12 +25,13 @@ public class RedisBungeeConfiguration {
 
     private final boolean handleReconnectToLastServer;
     private final boolean handleMotd;
+    private final HandleMotdOrder handleMotdOrder;
 
     private final CommandsConfiguration commandsConfiguration;
     private final String networkId;
 
 
-    public RedisBungeeConfiguration(String networkId, String proxyId, List<String> exemptAddresses, boolean kickWhenOnline, boolean handleReconnectToLastServer, boolean handleMotd, CommandsConfiguration commandsConfiguration) {
+    public RedisBungeeConfiguration(String networkId, String proxyId, List<String> exemptAddresses, boolean kickWhenOnline, boolean handleReconnectToLastServer, boolean handleMotd, HandleMotdOrder handleMotdOrder, CommandsConfiguration commandsConfiguration) {
         this.proxyId = proxyId;
         ImmutableList.Builder<InetAddress> addressBuilder = ImmutableList.builder();
         for (String s : exemptAddresses) {
@@ -40,6 +41,7 @@ public class RedisBungeeConfiguration {
         this.kickWhenOnline = kickWhenOnline;
         this.handleReconnectToLastServer = handleReconnectToLastServer;
         this.handleMotd = handleMotd;
+        this.handleMotdOrder = handleMotdOrder;
         this.commandsConfiguration = commandsConfiguration;
         this.networkId = networkId;
     }
@@ -58,6 +60,10 @@ public class RedisBungeeConfiguration {
 
     public boolean handleMotd() {
         return this.handleMotd;
+    }
+
+    public HandleMotdOrder handleMotdPriority() {
+        return handleMotdOrder;
     }
 
     public boolean handleReconnectToLastServer() {

--- a/api/src/main/java/com/imaginarycode/minecraft/redisbungee/api/config/RedisBungeeConfiguration.java
+++ b/api/src/main/java/com/imaginarycode/minecraft/redisbungee/api/config/RedisBungeeConfiguration.java
@@ -62,7 +62,7 @@ public class RedisBungeeConfiguration {
         return this.handleMotd;
     }
 
-    public HandleMotdOrder handleMotdPriority() {
+    public HandleMotdOrder handleMotdOrder() {
         return handleMotdOrder;
     }
 

--- a/api/src/main/java/com/imaginarycode/minecraft/redisbungee/api/config/loaders/ConfigLoader.java
+++ b/api/src/main/java/com/imaginarycode/minecraft/redisbungee/api/config/loaders/ConfigLoader.java
@@ -14,6 +14,7 @@ package com.imaginarycode.minecraft.redisbungee.api.config.loaders;
 import com.google.common.reflect.TypeToken;
 import com.imaginarycode.minecraft.redisbungee.api.RedisBungeeMode;
 import com.imaginarycode.minecraft.redisbungee.api.RedisBungeePlugin;
+import com.imaginarycode.minecraft.redisbungee.api.config.HandleMotdOrder;
 import com.imaginarycode.minecraft.redisbungee.api.config.RedisBungeeConfiguration;
 import com.imaginarycode.minecraft.redisbungee.api.summoners.JedisClusterSummoner;
 import com.imaginarycode.minecraft.redisbungee.api.summoners.JedisPooledSummoner;
@@ -104,6 +105,16 @@ public interface ConfigLoader extends GenericConfigLoader {
         plugin.logInfo("handle reconnect to last server: {}", reconnectToLastServer);
         plugin.logInfo("handle motd: {}", handleMotd);
 
+        HandleMotdOrder handleMotdOrder = HandleMotdOrder.NORMAL;
+        String handleMotdOrderName = node.getNode("handle-motd-priority").getString();
+        if (handleMotdOrderName != null) {
+            try {
+                handleMotdOrder = HandleMotdOrder.valueOf(handleMotdOrderName.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException e) {
+                plugin.logWarn("handle motd order value '{}' is unsupported (allowed: {})", handleMotdOrderName, HandleMotdOrder.values());
+            }
+        }
+        plugin.logInfo("handle motd order: {}", handleMotdOrder);
 
         // commands
         boolean redisBungeeEnabled = node.getNode("commands", "redisbungee", "enabled").getBoolean(true);
@@ -130,7 +141,8 @@ public interface ConfigLoader extends GenericConfigLoader {
         boolean installPlist = node.getNode("commands", "redisbungee-legacy", "subcommands", "plist", "install").getBoolean(false);
 
 
-        RedisBungeeConfiguration configuration = new RedisBungeeConfiguration(networkId, proxyId, exemptAddresses, kickWhenOnline, reconnectToLastServer, handleMotd, new RedisBungeeConfiguration.CommandsConfiguration(
+        RedisBungeeConfiguration configuration = new RedisBungeeConfiguration(networkId, proxyId, exemptAddresses, kickWhenOnline, reconnectToLastServer, handleMotd, handleMotdOrder,
+            new RedisBungeeConfiguration.CommandsConfiguration(
                 redisBungeeEnabled, redisBungeeLegacyEnabled,
                 new RedisBungeeConfiguration.LegacySubCommandsConfiguration(
                         findEnabled, glistEnabled, ipEnabled,

--- a/api/src/main/resources/config.yml
+++ b/api/src/main/resources/config.yml
@@ -77,6 +77,13 @@ kick-when-online: true
 # you can disable this when you want to handle motd yourself, use RedisBungee api to get total players when needed :)
 handle-motd: true
 
+# MOTD plugins compatibility setting
+# Allowed values: FIRST, NORMAL, LAST
+# This option enables RedisBungee to manage various interactions between other plugins and the online player count,
+# which is dynamically updated to a global player count in ping responses if the handle-motd option is enabled.
+# If you encounter issues with other plugins accessing or modifying the player count, try using a value of FIRST or LAST.
+handle-motd-order: NORMAL
+
 # A list of IP addresses for which RedisBungee will not modify the response for, useful for automatic
 # restart scripts.
 # Automatically disabled  if handle-motd is disabled.

--- a/proxies/bungeecord/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
+++ b/proxies/bungeecord/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
@@ -18,7 +18,6 @@ import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import com.imaginarycode.minecraft.redisbungee.api.RedisBungeePlugin;
 import com.imaginarycode.minecraft.redisbungee.api.config.HandleMotdOrder;
-import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
 import net.md_5.bungee.api.AbstractReconnectHandler;
 import net.md_5.bungee.api.ProxyServer;
@@ -46,7 +45,7 @@ public class RedisBungeeListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     private void onPingFirst(ProxyPingEvent event) {
-        if (plugin.configuration().handleMotdPriority() != HandleMotdOrder.FIRST) {
+        if (plugin.configuration().handleMotdOrder() != HandleMotdOrder.FIRST) {
             return;
         }
         onPing0(event);
@@ -54,7 +53,7 @@ public class RedisBungeeListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL)
     private void onPingNormal(ProxyPingEvent event) {
-        if (plugin.configuration().handleMotdPriority() != HandleMotdOrder.NORMAL) {
+        if (plugin.configuration().handleMotdOrder() != HandleMotdOrder.NORMAL) {
             return;
         }
         onPing0(event);
@@ -62,7 +61,7 @@ public class RedisBungeeListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     private void onPingLast(ProxyPingEvent event) {
-        if (plugin.configuration().handleMotdPriority() != HandleMotdOrder.LAST) {
+        if (plugin.configuration().handleMotdOrder() != HandleMotdOrder.LAST) {
             return;
         }
         onPing0(event);

--- a/proxies/bungeecord/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
+++ b/proxies/bungeecord/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
@@ -17,6 +17,7 @@ import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import com.imaginarycode.minecraft.redisbungee.api.RedisBungeePlugin;
+import com.imaginarycode.minecraft.redisbungee.api.config.HandleMotdOrder;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
 import net.md_5.bungee.api.AbstractReconnectHandler;
@@ -29,6 +30,7 @@ import net.md_5.bungee.api.event.ProxyPingEvent;
 import net.md_5.bungee.api.event.ServerConnectEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
+import net.md_5.bungee.event.EventPriority;
 
 import java.util.*;
 
@@ -42,8 +44,31 @@ public class RedisBungeeListener implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler
-    public void onPing(ProxyPingEvent event) {
+    @EventHandler(priority = EventPriority.LOWEST)
+    private void onPingFirst(ProxyPingEvent event) {
+        if (plugin.configuration().handleMotdPriority() != HandleMotdOrder.FIRST) {
+            return;
+        }
+        onPing0(event);
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL)
+    private void onPingNormal(ProxyPingEvent event) {
+        if (plugin.configuration().handleMotdPriority() != HandleMotdOrder.NORMAL) {
+            return;
+        }
+        onPing0(event);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    private void onPingLast(ProxyPingEvent event) {
+        if (plugin.configuration().handleMotdPriority() != HandleMotdOrder.LAST) {
+            return;
+        }
+        onPing0(event);
+    }
+
+    private void onPing0(ProxyPingEvent event) {
         if (!plugin.configuration().handleMotd()) return;
         if (plugin.configuration().getExemptAddresses().contains(event.getConnection().getAddress().getAddress())) return;
         ServerInfo forced = AbstractReconnectHandler.getForcedHost(event.getConnection());

--- a/proxies/velocity/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
+++ b/proxies/velocity/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
@@ -17,6 +17,7 @@ import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import com.imaginarycode.minecraft.redisbungee.api.RedisBungeePlugin;
+import com.imaginarycode.minecraft.redisbungee.api.config.HandleMotdOrder;
 import com.velocitypowered.api.event.PostOrder;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.connection.PluginMessageEvent;
@@ -41,8 +42,31 @@ public class RedisBungeeListener {
         this.plugin = plugin;
     }
 
-    @Subscribe(order = PostOrder.LAST) // some plugins changes it online players so we need to be executed as last
-    public void onPing(ProxyPingEvent event) {
+    @Subscribe(order = PostOrder.FIRST)
+    public void onPingFirst(ProxyPingEvent event) {
+        if (plugin.configuration().handleMotdPriority() != HandleMotdOrder.FIRST) {
+            return;
+        }
+        onPing0(event);
+    }
+
+    @Subscribe(order = PostOrder.NORMAL)
+    public void onPingNormal(ProxyPingEvent event) {
+        if (plugin.configuration().handleMotdPriority() != HandleMotdOrder.NORMAL) {
+            return;
+        }
+        onPing0(event);
+    }
+
+    @Subscribe(order = PostOrder.LAST)
+    public void onPingLast(ProxyPingEvent event) {
+        if (plugin.configuration().handleMotdPriority() != HandleMotdOrder.LAST) {
+            return;
+        }
+        onPing0(event);
+    }
+
+    private void onPing0(ProxyPingEvent event) {
         if (!plugin.configuration().handleMotd()) return;
         if (plugin.configuration().getExemptAddresses().contains(event.getConnection().getRemoteAddress().getAddress())) return;
 

--- a/proxies/velocity/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
+++ b/proxies/velocity/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
@@ -44,7 +44,7 @@ public class RedisBungeeListener {
 
     @Subscribe(order = PostOrder.FIRST)
     public void onPingFirst(ProxyPingEvent event) {
-        if (plugin.configuration().handleMotdPriority() != HandleMotdOrder.FIRST) {
+        if (plugin.configuration().handleMotdOrder() != HandleMotdOrder.FIRST) {
             return;
         }
         onPing0(event);
@@ -52,7 +52,7 @@ public class RedisBungeeListener {
 
     @Subscribe(order = PostOrder.NORMAL)
     public void onPingNormal(ProxyPingEvent event) {
-        if (plugin.configuration().handleMotdPriority() != HandleMotdOrder.NORMAL) {
+        if (plugin.configuration().handleMotdOrder() != HandleMotdOrder.NORMAL) {
             return;
         }
         onPing0(event);
@@ -60,7 +60,7 @@ public class RedisBungeeListener {
 
     @Subscribe(order = PostOrder.LAST)
     public void onPingLast(ProxyPingEvent event) {
-        if (plugin.configuration().handleMotdPriority() != HandleMotdOrder.LAST) {
+        if (plugin.configuration().handleMotdOrder() != HandleMotdOrder.LAST) {
             return;
         }
         onPing0(event);


### PR DESCRIPTION
Currently, the bungee implementation is using NORMAL priority for the ping event handler, while the velocity implementation is using LAST. Regardless of which choice may be the better one, this is an inconsistency that this patch addresses by using NORMAL as the default for both platforms.

Additionally to addressing the inconsistency, this patch adds a new config option `handle-motd-order` which uses velocity's event priority nomenclature to allow configuring the behavior of the MOTD handling on both platforms.

In cases where there is a MOTD plugin that incorrectly overrides a player count using the local player count, one may choose to use order LAST to override the value back to the global player count.

In cases where there is a MOTD plugin that relies on a player count value from the ping response, one may choose to use order FIRST to make sure the response will have the correct global player count.

Fixes https://github.com/ProxioDev/ValioBungee/issues/107