### PR TITLE
Storage fill-up fix

### DIFF
--- a/api/src/main/java/com/imaginarycode/minecraft/redisbungee/api/ProxyDataManager.java
+++ b/api/src/main/java/com/imaginarycode/minecraft/redisbungee/api/ProxyDataManager.java
@@ -374,6 +374,7 @@ public abstract class ProxyDataManager implements Runnable {
                         }
                     }
                 }
+                unifiedJedis.xdel(STREAM_ID,this.lastStreamEntryID); //CLEAN-UP of the stream, otherwise the STREAM would fill-up over time and take space - petulikan1
             } catch (Exception e) {
                 this.plugin.logFatal("an error has occurred in the stream", e);
                 try {


### PR DESCRIPTION
Hey there, I was looking at my redis database and found out that the streams have a flaw that would unnecessarily over-time take storage. 

This first image is after a while of starting up the server
![image](https://github.com/user-attachments/assets/0336c6ba-a013-42cc-bf7a-1c72e79fd6c4)

Here this second image is after 10 minutes of starting the server up. 
**This was just 1 single server and without any players**
![image](https://github.com/user-attachments/assets/feaa20bc-855a-4e7b-b607-93e173f0a0ce)


Now imagine a bigger network with more players... This could eventually by running for 1 whole year on such network take a few GB's of space.

I looked trough the code and figured out where this problem could be addressed and after looking trough the methods, one occured to me that could work.
Tried the code and worked as it should - no more messages were appearing and after deleting the stream, it was recreated again by RedisBungee and it stayed at 0 entries resulting in not filling up any more storage. 

